### PR TITLE
Change options button width when statistics are disabled

### DIFF
--- a/src/css/base.css
+++ b/src/css/base.css
@@ -66,7 +66,7 @@ button.small {
 }
 
 button.popup {
-	width: 100%;
+	width: 150px;
 }
 
 button.margin {

--- a/src/javascript/pages/popup.js
+++ b/src/javascript/pages/popup.js
@@ -243,7 +243,7 @@ function eventListeners() {
 
 	} else { // Stats disabled. Hide button.
 
-		// Change display ststus of stats button
+		// Change display status of stats button
 		ui.display('stats', false);
 
 		// Change width of options button to 150px

--- a/src/javascript/pages/popup.js
+++ b/src/javascript/pages/popup.js
@@ -243,8 +243,11 @@ function eventListeners() {
 
 	} else { // Stats disabled. Hide button.
 
-		// Change visibility of button
+		// Change display ststus of stats button
 		ui.display('stats', false);
+
+		// Change width of options button to 150px
+		ui.addClass('options', 'popup');
 
 	}
 


### PR DESCRIPTION
Changes options button width to match the width of the pop-up window when statistics button is disabled. closes #52 