### PR TITLE
Remove encodeURI() from archive()

### DIFF
--- a/src/javascript/archive.js
+++ b/src/javascript/archive.js
@@ -11,7 +11,7 @@
 function archive(url, callback) {
 
 	var request = new Request();
-	request.get(global.urls.save + encodeURI(url), function (response) {
+	request.get(global.urls.save + url, function (response) {
 
 		var headers = response.headers,
 			statusCode = response.status.toString(),


### PR DESCRIPTION
URLs returned by browser.tabs.query are already encoded. No need to encode them again.