### PR TITLE
[manifest_firefox.json] Lower strict_min_version value (57 -> 56)

### DIFF
--- a/src/manifest_firefox.json
+++ b/src/manifest_firefox.json
@@ -1,7 +1,7 @@
 {
 	"applications": {
 		"gecko": {
-			"strict_min_version": "57.0"
+			"strict_min_version": "56.0"
 		}
 	},
 	"name": "__MSG_extensionName__",


### PR DESCRIPTION
Lower `strict_min_version` value to allow the extension to be installed on WebExtension compatible forks of Firefox. Closes #105