### PR TITLE
[messages.json][en] Fix typo (unkown -> unknown)

### DIFF
--- a/src/_locales/en/messages.json
+++ b/src/_locales/en/messages.json
@@ -55,7 +55,7 @@
 	},
 
 	"ArchiveFailedDefault": {
-		"message": "An unkown error occurred. \r\n Try again later.",
+		"message": "An unknown error occurred. \r\n Try again later.",
 		"description": "Default archive failed error text"
 	},
 


### PR DESCRIPTION
Fix typo in message string for 'ArchiveFailedDefault'.