### PR TITLE
[popup.js] Use tabs.query API property 'pendingUrl'

### DIFF
--- a/src/javascript/pages/popup.js
+++ b/src/javascript/pages/popup.js
@@ -266,9 +266,19 @@ browser.tabs.query({
 	currentWindow: true,
 	active: true
 }, function (tabs) {
+	var tab = tabs[0];
 
-	// Set URL
-	url = tabs[0].url;
+	console.log(tabs[0]);
+
+	/*
+		Since chrome 79 (Dec 2019), the property 'pendingUrl' is returned by the tabs.query API when a tab is loading.
+		Firefox (71) does not currently support is property.
+	*/
+	if (tab.status === 'loading' && tab.hasOwnProperty('pendingUrl')) {
+		url = tabs[0].pendingUrl;
+	} else {
+		url = tabs[0].url;
+	}
 
 	// Load setting and run the start function
 	settings.load(start);

--- a/src/javascript/pages/popup.js
+++ b/src/javascript/pages/popup.js
@@ -268,8 +268,6 @@ browser.tabs.query({
 }, function (tabs) {
 	var tab = tabs[0];
 
-	console.log(tabs[0]);
-
 	/*
 		Since chrome 79 (Dec 2019), the property 'pendingUrl' is returned by the tabs.query API when a tab is loading.
 		Firefox (71) does not currently support is property.

--- a/src/javascript/pages/popup.js
+++ b/src/javascript/pages/popup.js
@@ -270,7 +270,7 @@ browser.tabs.query({
 
 	/*
 		Since chrome 79 (Dec 2019), the property 'pendingUrl' is returned by the tabs.query API when a tab is loading.
-		Firefox (71) does not currently support is property.
+		Firefox (71) does not currently support this property.
 	*/
 	if (tab.status === 'loading' && tab.hasOwnProperty('pendingUrl')) {
 		url = tabs[0].pendingUrl;

--- a/src/javascript/pages/popup.js
+++ b/src/javascript/pages/popup.js
@@ -268,10 +268,9 @@ browser.tabs.query({
 }, function (tabs) {
 	var tab = tabs[0];
 
-	/*
-		Since chrome 79 (Dec 2019), the property 'pendingUrl' is returned by the tabs.query API when a tab is loading.
-		Firefox (71) does not currently support this property.
-	*/
+	
+	// Since chrome 79 (Dec 2019), the property 'pendingUrl' is returned by the tabs.query API when a tab is loading.
+	// Firefox (71) does not currently support this property.
 	if (tab.status === 'loading' && tab.hasOwnProperty('pendingUrl')) {
 		url = tabs[0].pendingUrl;
 	} else {


### PR DESCRIPTION
This pull request updates the `browser.tabs.query` callback in `popup.js` to use the property `pendingUrl` when it is returned by the `tabs.query` API.

The property `pendingUrl` was added in Google Chrome 79 (Dec 2019), and is returned when the active tab is loading. Firefox does not currently support the property.

> Announcement: Upcoming change to make the url property on Tabs more reliable. (October 11, 2019)
> https://groups.google.com/a/chromium.org/forum/#!topic/chromium-extensions/5zu_PT0arls

> chrome.tabs
> https://developer.chrome.com/extensions/tabs#property-Tab-pendingUrl
