### PR TITLE
Add support for opening archived pages, links and images via the context menu

### DIFF
--- a/src/_locales/en/messages.json
+++ b/src/_locales/en/messages.json
@@ -24,6 +24,21 @@
 		"description": "Title of context menu item that saves a image to the Wayback Machine."
 	},
 
+	"MenuItemViewArchivedPage": {
+		"message": "View Archived Page",
+		"description": "Title of context menu item that opens an archived version of a page."
+	},
+
+	"MenuItemViewArchivedImage": {
+		"message": "View Archived Image",
+		"description": "Title of context menu item that opens an archived version of an image."
+	},
+
+	"MenuItemViewArchivedLink": {
+		"message": "View Archived Link",
+		"description": "Title of context menu item that opens an archived version of a link."
+	},
+
 	"notificationArchiveFailed": {
 		"message": "Page Not Archived",
 		"description": "Title of notification that tells the user that the page was not archived."

--- a/src/html/options.html
+++ b/src/html/options.html
@@ -117,21 +117,21 @@
 				</label>
 			</div>
 			<div class="option child">
-				<label class="checkbox">
+				<label title="Adds a right click menu option for archiving pages." class="checkbox">
 					<input type="checkbox" id="context_menu_page" />
 					<span></span>
 					<p class="text">Enable 'Archive Page' option.</p>
 				</label>
 			</div>
 			<div class="option child">
-				<label class="checkbox">
+				<label title="Adds a right click menu option for archiving links." class="checkbox">
 					<input type="checkbox" id="context_menu_link" />
 					<span></span>
 					<p class="text">Enable 'Archive Link' option.</p>
 				</label>
 			</div>
 			<div class="option child">
-				<label class="checkbox">
+				<label title="Adds a right click menu option for archiving images." class="checkbox">
 					<input type="checkbox" id="context_menu_image" />
 					<span></span>
 					<p class="text">Enable 'Archive Image' option.</p>

--- a/src/html/options.html
+++ b/src/html/options.html
@@ -137,6 +137,27 @@
 					<p class="text">Enable 'Archive Image' option.</p>
 				</label>
 			</div>
+			<div class="option child">
+				<label title="Adds a right click menu option for viewing archived versions of a page." class="checkbox">
+					<input type="checkbox" id="context_menu_view_page" />
+					<span></span>
+					<p class="text">Enable 'View Archived Page' option.</p>
+				</label>
+			</div>
+			<div class="option child">
+				<label title="Adds a right click menu option for viewing archived versions of a link." class="checkbox">
+					<input type="checkbox" id="context_menu_view_link" />
+					<span></span>
+					<p class="text">Enable 'View Archived Link' option.</p>
+				</label>
+			</div>
+			<div class="option child">
+				<label title="Adds a right click menu option for viewing archived versions of an image." class="checkbox">
+					<input type="checkbox" id="context_menu_view_image" />
+					<span></span>
+					<p class="text">Enable 'View Archived Image' option.</p>
+				</label>
+			</div>
 			<div class="option bottom">
 				<label class="checkbox">
 					<input type="checkbox" id="context_note" />

--- a/src/javascript/pages/background.js
+++ b/src/javascript/pages/background.js
@@ -1,5 +1,5 @@
 /*jslint node: true */
-/*global Stats, Settings, Notify, validate, archive, browser, Debug, console */
+/*global Stats, Settings, Notify, validate, archive, browser, Debug, global, console */
 "use strict";
 
 var settings = new Settings(),
@@ -9,7 +9,10 @@ var settings = new Settings(),
 	contextMenuSet = {
 		'archivePage': false,
 		'archiveLink': false,
-		'archiveImage': false
+		'archiveImage': false,
+		'viewArchivedPage': false,
+		'viewArchivedLink': false,
+		'viewArchivedImage': false
 	};
 
 /**
@@ -64,7 +67,6 @@ function contextMenus() {
 
 		// Pages
 		if (contextMenuSet.archivePage === false && settings.get('contextMenuArchive').page === true) {
-
 			contextMenuCreate(
 				'archivePage',
 				'page',
@@ -72,14 +74,11 @@ function contextMenus() {
 			);
 
 		} else if (contextMenuSet.archivePage === true && settings.get('contextMenuArchive').page === false) {
-
 			contextMenuRemove('archivePage');
-
 		}
 
 		// Links
 		if (contextMenuSet.archiveLink === false && settings.get('contextMenuArchive').link === true) {
-
 			contextMenuCreate(
 				'archiveLink',
 				'link',
@@ -87,14 +86,11 @@ function contextMenus() {
 			);
 
 		} else if (contextMenuSet.archiveLink === true && settings.get('contextMenuArchive').link === false) {
-
 			contextMenuRemove('archiveLink');
-
 		}
 
 		// Images
 		if (contextMenuSet.archiveImage === false && settings.get('contextMenuArchive').image === true) {
-
 			contextMenuCreate(
 				'archiveImage',
 				'image',
@@ -102,16 +98,52 @@ function contextMenus() {
 			);
 
 		} else if (contextMenuSet.archiveImage === true && settings.get('contextMenuArchive').image === false) {
-
 			contextMenuRemove('archiveImage');
+		}
+		
+		// View archived page
+		if (contextMenuSet.viewArchivedPage === false && settings.get('contextMenuViewArchived').page === true) {
+			contextMenuCreate(
+				'viewArchivedPage',
+				'page',
+				browser.i18n.getMessage('MenuItemViewArchivedPage')
+			);
 
+		} else if (contextMenuSet.viewArchivedPage === true && settings.get('contextMenuViewArchived').page === false) {
+			contextMenuRemove('viewArchivedPage');
+		}
+		
+		// View archived link
+		if (contextMenuSet.viewArchivedLink === false && settings.get('contextMenuViewArchived').link === true) {
+			contextMenuCreate(
+				'viewArchivedLink',
+				'link',
+				browser.i18n.getMessage('MenuItemViewArchivedLink')
+			);
+
+		} else if (contextMenuSet.viewArchivedLink === true && settings.get('contextMenuViewArchived').link === false) {
+			contextMenuRemove('viewArchivedLink');
+		}
+		
+		// View archived image
+		if (contextMenuSet.viewArchivedImage === false && settings.get('contextMenuViewArchived').image === true) {
+			contextMenuCreate(
+				'viewArchivedImage',
+				'image',
+				browser.i18n.getMessage('MenuItemViewArchivedImage')
+			);
+
+		} else if (contextMenuSet.viewArchivedImage === true && settings.get('contextMenuViewArchived').image === false) {
+			contextMenuRemove('viewArchivedImage');
 		}
 	} else { // Context menu options disabled, remove all options.
 
 		contextMenuRemove('archivePage');
 		contextMenuRemove('archiveLink');
 		contextMenuRemove('archiveImage');
-
+		contextMenuRemove('viewArchivedPage');
+		contextMenuRemove('viewArchivedLink');
+		contextMenuRemove('viewArchivedImage');
 	}
 }
 

--- a/src/javascript/pages/background.js
+++ b/src/javascript/pages/background.js
@@ -264,23 +264,46 @@ browser.storage.onChanged.addListener(function () {
 
 // Listener for context menu link
 browser.contextMenus.onClicked.addListener(function (info) {
+	var archivePage = false,
+		url;
+	
+	if (info.hasOwnProperty('pageUrl')) {
+		if (info.menuItemId === 'archivePage') {
+			archivePage = true;
+		}
 
-	var url = info.pageUrl;
+		url = info.pageUrl;
+	}
+	
+	if (info.hasOwnProperty('linkUrl')) {
+		if (info.menuItemId === 'archiveLink') {
+			archivePage = true;
+		}
 
-	if (info.menuItemId === 'archiveLink') {
 		url = info.linkUrl;
 	}
+	
+	if (info.hasOwnProperty('srcUrl')) {
+		if (info.menuItemId === 'archiveImage') {
+			archivePage = true;
+		}
 
-	if (info.menuItemId === 'archiveImage') {
 		url = info.srcUrl;
 	}
 
 	settings.load(function () {
 
 		validate(url, function (status) {
-
 			if (status === true) {
-				archive(url, wasArchived); // Save the page
+				if (archivePage === true) { // Archive page 
+					archive(url, wasArchived);
+				}
+
+				if (archivePage === false) { // View archived page
+					browser.tabs.create({
+						url: global.urls.base + '/web/2/' + url
+					});
+				}
 
 			} else { // Failed, show notification
 
@@ -292,7 +315,6 @@ browser.contextMenus.onClicked.addListener(function (info) {
 			}
 		});
 	});
-
 });
 
 browser.runtime.onInstalled.addListener(function (details) {

--- a/src/javascript/pages/options.js
+++ b/src/javascript/pages/options.js
@@ -47,6 +47,9 @@ function displaySettings(showDefaults) {
 	document.getElementById('context_menu_page').checked = list.contextMenuArchive.page;
 	document.getElementById('context_menu_link').checked = list.contextMenuArchive.link;
 	document.getElementById('context_menu_image').checked = list.contextMenuArchive.image;
+	document.getElementById('context_menu_view_page').checked = list.contextMenuViewArchived.page;
+	document.getElementById('context_menu_view_link').checked = list.contextMenuViewArchived.link;
+	document.getElementById('context_menu_view_image').checked = list.contextMenuViewArchived.image;
 
 	// Notifications
 	document.getElementById('context_note').checked = list.contextMenuNote;
@@ -68,6 +71,10 @@ function displaySettings(showDefaults) {
 		ui.disableInput('context_menu_page');
 		ui.disableInput('context_menu_link');
 		ui.disableInput('context_menu_image');
+		
+		ui.disableInput('context_menu_view_page');
+		ui.disableInput('context_menu_view_link');
+		ui.disableInput('context_menu_view_image');
 		ui.disableInput('context_note');
 	}
 
@@ -178,6 +185,11 @@ function saveSettings() {
 			'link': document.getElementById('context_menu_link').checked,
 			'image': document.getElementById('context_menu_image').checked
 		},
+		contextMenuViewArchived: {
+			'page': document.getElementById('context_menu_view_page').checked,
+			'link': document.getElementById('context_menu_view_link').checked,
+			'image': document.getElementById('context_menu_view_image').checked
+		},
 		contextMenuNote: document.getElementById('context_note').checked,
 
 		notePlayAlert: document.getElementById('note_sound').checked,
@@ -250,11 +262,17 @@ function inputEventHandler(event) {
 			ui.enableInput('context_menu_page');
 			ui.enableInput('context_menu_link');
 			ui.enableInput('context_menu_image');
+			ui.enableInput('context_menu_view_page');
+			ui.enableInput('context_menu_view_link');
+			ui.enableInput('context_menu_view_image');
 			ui.enableInput('context_note');
 		} else {
 			ui.disableInput('context_menu_page');
 			ui.disableInput('context_menu_link');
 			ui.disableInput('context_menu_image');
+			ui.disableInput('context_menu_view_page');
+			ui.disableInput('context_menu_view_link');
+			ui.disableInput('context_menu_view_image');
 			ui.disableInput('context_note');
 		}
 

--- a/src/javascript/settings.js
+++ b/src/javascript/settings.js
@@ -30,6 +30,11 @@ function Settings() {
 				'link': true,
 				'image': true
 			},
+			contextMenuViewArchived: { // View archived content context menu options
+				'page': true,
+				'link': true,
+				'image': true
+			},
 			contextMenuNote: true, // Display notification if a page, link or image cannot be archived via the context menu.
 
 			// Notifications


### PR DESCRIPTION
This pull request adds support for opening archived versions of pages, links and images via the context menu. Each context menu item can be enabled or disabled in the options page.
![Untitled](https://user-images.githubusercontent.com/20118140/74672100-77865480-51a4-11ea-9d4f-db2922d5e0e8.png)
