### PR TITLE
[snapshot.js] Use POST method when making requests to Wayback Availability API

### DIFF
--- a/src/javascript/snapshot.js
+++ b/src/javascript/snapshot.js
@@ -11,25 +11,25 @@ function Snapshot() {
 	 * @param {callback} callback
 	 */
 	this.get = function get(url, callback) {
-		var request = new Request();
-		request.get(global.urls.api + encodeURIComponent(url), function (response) {
+		var request = new Request(),
+			contentType = 'application/x-www-form-urlencoded',
+			payload = 'url=' + encodeURIComponent(url);
 
+		request.post(global.urls.api, contentType, payload, function (response) {
 			var snapshot = {
 				available: false,
-				error: false,
+				error: true,
 				timestamp: ''
 			};
 
-			if (response.status !== 200) {
-				snapshot.error = true;
-			}
-
 			if (response.status === 200) {
+				snapshot.error = false;
+
 				var data = JSON.parse(response.data);
 
-				if (data.archived_snapshots.hasOwnProperty('closest')) {
-					snapshot.available = data.archived_snapshots.closest.available;
-					snapshot.timestamp = data.archived_snapshots.closest.timestamp;
+				if (data.results[0].archived_snapshots.hasOwnProperty('closest')) {
+					snapshot.available = data.results[0].archived_snapshots.closest.available;
+					snapshot.timestamp = data.results[0].archived_snapshots.closest.timestamp;
 				}
 			}
 


### PR DESCRIPTION
Updates `get()` in `snapshot.js` to use POST request method when making requests to the Wayback Availability API.