### PR TITLE
[global.js] Use chrome-api.archive.org endpoint for Availability API

### DIFF
--- a/src/javascript/global.js
+++ b/src/javascript/global.js
@@ -10,7 +10,7 @@ var global = {
 		base: 'https://web.archive.org',
 		save: 'https://web.archive.org/save/',
 		calendar: 'https://web.archive.org/web/*/',
-		api: 'https://archive.org/wayback/available?url='
+		api: 'https://chrome-api.archive.org/wayback/available'
 	},
 
 	// URL and IPv4 validation with hostname capture


### PR DESCRIPTION
Changes Availability API endpoint to the same endpoint used by the Internet Archive's official extension.