### PR TITLE
remove version_name from manifest.json

### DIFF
--- a/src/manifest.json
+++ b/src/manifest.json
@@ -4,7 +4,6 @@
 	"author": "VerifiedJoseph",
 	"default_locale": "en",
 	"version": "5.6.1",
-	"version_name": "5.6.1",
 	"manifest_version": 2,
 	"icons": {
 		"16": "images/icons/16.png",


### PR DESCRIPTION
Based on the spec, and based on the warning in Firefox, and based on other web extensions I maintain; it appears the `version_name` field isn't needed.

Having said that, I'm aware it was intentionally added back in 2016 ([changelog](https://github.com/VerifiedJoseph/Save-to-the-Wayback-Machine/blob/0cdff9485bf0e90455d5ed33c5d5918a98abd0f2/CHANGELOG.md#350---2016-04-15)), so perhaps it's needed for something specific that I'm not familiar with?

<img width="662" alt="Screenshot" src="https://user-images.githubusercontent.com/156867/174127251-223126ee-a12a-4d14-9405-1e994b836987.png">
